### PR TITLE
Sync code examples, use Rust 2018 `use` instead of `extern crate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,8 @@ Cargo.lock
 
 
 # End of https://www.gitignore.io/api/rust
+
+
+# vim
+*.swp
+*~

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ const VEC_LENGTH: usize = 100;
 
 benchmarking::warm_up();
 
-let bench_result = benchmarking::measure_function(|measurer| {
+let bench_result = benchmarking::bench_function(|measurer| {
     let mut vec: Vec<usize> = Vec::with_capacity(VEC_LENGTH);
 
     unsafe {
@@ -22,13 +22,12 @@ let bench_result = benchmarking::measure_function(|measurer| {
     }
 
     for i in 0..VEC_LENGTH {
-        measurer.measure(|| {
-            vec[i]
-        });
+        measurer.measure(|| vec[i]);
     }
 
     vec
-}).unwrap();
+})
+.unwrap();
 
 println!("Reading a number from a vec takes {:?}!", bench_result.elapsed());
 ```
@@ -40,7 +39,7 @@ const VEC_LENGTH: usize = 100;
 
 benchmarking::warm_up();
 
-let bench_result = benchmarking::measure_function(|measurer| {
+let bench_result = benchmarking::bench_function(|measurer| {
     let mut vec: Vec<usize> = Vec::with_capacity(VEC_LENGTH);
 
     measurer.measure(|| {
@@ -50,7 +49,8 @@ let bench_result = benchmarking::measure_function(|measurer| {
     });
 
     vec
-}).unwrap();
+})
+.unwrap();
 
 println!("Filling 0 to 99 into a vec takes {:?}!", bench_result.elapsed());
 ```
@@ -62,17 +62,18 @@ const VEC_LENGTH: usize = 100;
 
 benchmarking::warm_up();
 
-let bench_result = benchmarking::measure_function(|measurer| {
+let bench_result = benchmarking::bench_function(|measurer| {
     let mut vec: Vec<usize> = Vec::with_capacity(VEC_LENGTH);
 
-    for loop_seq in 0..VEC_LENGTH {
+    for i in 0..VEC_LENGTH {
         measurer.measure(|| {
-            vec.push(loop_seq);
+            vec.push(i);
         });
     }
 
     vec
-}).unwrap();
+})
+.unwrap();
 
 println!("Pushing a number into a vec takes {:?}!", bench_result.elapsed());
 ```
@@ -84,7 +85,7 @@ const VEC_LENGTH: usize = 100;
 
 benchmarking::warm_up();
 
-let bench_result = benchmarking::measure_function_n(2, |measurers| {
+let bench_result = benchmarking::bench_function_n(2, |measurers| {
     let mut vec: Vec<usize> = Vec::with_capacity(VEC_LENGTH);
 
     for i in 0..VEC_LENGTH {
@@ -94,13 +95,12 @@ let bench_result = benchmarking::measure_function_n(2, |measurers| {
     }
 
     for i in 0..VEC_LENGTH {
-        measurers[0].measure(|| {
-            vec[i]
-        });
+        measurers[0].measure(|| vec[i]);
     }
 
     vec
-}).unwrap();
+})
+.unwrap();
 
 println!("Reading a number from a vec takes {:?}!", bench_result[0].elapsed());
 println!("Pushing a number into a vec takes {:?}!", bench_result[1].elapsed());

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This crate can be used to execute something and measure the execution time. It d
 ## Examples
 
 ```rust
-extern crate benchmarking;
+use benchmarking;
 
 const VEC_LENGTH: usize = 100;
 
@@ -33,7 +33,7 @@ println!("Reading a number from a vec takes {:?}!", bench_result.elapsed());
 ```
 
 ```rust
-extern crate benchmarking;
+use benchmarking;
 
 const VEC_LENGTH: usize = 100;
 
@@ -56,7 +56,7 @@ println!("Filling 0 to 99 into a vec takes {:?}!", bench_result.elapsed());
 ```
 
 ```rust
-extern crate benchmarking;
+use benchmarking;
 
 const VEC_LENGTH: usize = 100;
 
@@ -79,7 +79,7 @@ println!("Pushing a number into a vec takes {:?}!", bench_result.elapsed());
 ```
 
 ```rust
-extern crate benchmarking;
+use benchmarking;
 
 const VEC_LENGTH: usize = 100;
 

--- a/examples/fill_a_number.rs
+++ b/examples/fill_a_number.rs
@@ -1,4 +1,4 @@
-extern crate benchmarking;
+use benchmarking;
 
 fn main() {
     const VEC_LENGTH: usize = 100;

--- a/examples/fill_numbers_0_to_99.rs
+++ b/examples/fill_numbers_0_to_99.rs
@@ -1,4 +1,4 @@
-extern crate benchmarking;
+use benchmarking;
 
 fn main() {
     const VEC_LENGTH: usize = 100;

--- a/examples/read_a_number.rs
+++ b/examples/read_a_number.rs
@@ -1,4 +1,4 @@
-extern crate benchmarking;
+use benchmarking;
 
 fn main() {
     const VEC_LENGTH: usize = 100;

--- a/examples/read_and_write.rs
+++ b/examples/read_and_write.rs
@@ -1,4 +1,4 @@
-extern crate benchmarking;
+use benchmarking;
 
 fn main() {
     const VEC_LENGTH: usize = 100;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! ## Examples
 //!
 //! ```rust
-//! extern crate benchmarking;
+//! use benchmarking;
 //!
 //! const VEC_LENGTH: usize = 100;
 //!
@@ -30,7 +30,7 @@
 //! ```
 //!
 //! ```rust
-//! extern crate benchmarking;
+//! use benchmarking;
 //!
 //! const VEC_LENGTH: usize = 100;
 //!
@@ -53,7 +53,7 @@
 //! ```
 //!
 //! ```rust
-//! extern crate benchmarking;
+//! use benchmarking;
 //!
 //! const VEC_LENGTH: usize = 100;
 //!
@@ -76,7 +76,7 @@
 //! ```
 //!
 //! ```rust
-//! extern crate benchmarking;
+//! use benchmarking;
 //!
 //! const VEC_LENGTH: usize = 100;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! benchmarking::warm_up();
 //!
-//! let bench_result = benchmarking::measure_function(|measurer| {
+//! let bench_result = benchmarking::bench_function(|measurer| {
 //!     let mut vec: Vec<usize> = Vec::with_capacity(VEC_LENGTH);
 //!
 //!     unsafe {
@@ -36,7 +36,7 @@
 //!
 //! benchmarking::warm_up();
 //!
-//! let bench_result = benchmarking::measure_function(|measurer| {
+//! let bench_result = benchmarking::bench_function(|measurer| {
 //!     let mut vec: Vec<usize> = Vec::with_capacity(VEC_LENGTH);
 //!
 //!     measurer.measure(|| {
@@ -59,12 +59,12 @@
 //!
 //! benchmarking::warm_up();
 //!
-//! let bench_result = benchmarking::measure_function(|measurer| {
+//! let bench_result = benchmarking::bench_function(|measurer| {
 //!     let mut vec: Vec<usize> = Vec::with_capacity(VEC_LENGTH);
 //!
-//!     for loop_seq in 0..VEC_LENGTH {
+//!     for i in 0..VEC_LENGTH {
 //!         measurer.measure(|| {
-//!             vec.push(loop_seq);
+//!             vec.push(i);
 //!         });
 //!     }
 //!
@@ -82,7 +82,7 @@
 //!
 //! benchmarking::warm_up();
 //!
-//! let bench_result = benchmarking::measure_function_n(2, |measurers| {
+//! let bench_result = benchmarking::bench_function_n(2, |measurers| {
 //!     let mut vec: Vec<usize> = Vec::with_capacity(VEC_LENGTH);
 //!
 //!     for i in 0..VEC_LENGTH {

--- a/sync-docs.pl
+++ b/sync-docs.pl
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+
+# This program replaces parts of the benchmarking crate's
+# README.md and src/lib.rs with sample code from examples/
+
+use 5.10.0;
+use strict;
+use warnings;
+use FindBin '$Bin';
+
+# Work with paths relative to this program's location
+chdir $Bin or die;
+
+my ($f, $body);
+
+# Read in the example programs in desired order, then any new ones
+my (@e, %seen);
+my @files =
+    map { "examples/$_" }
+    qw(
+        read_a_number.rs
+        fill_numbers_0_to_99.rs
+        fill_a_number.rs
+        read_and_write.rs
+    );
+push @files, glob("examples/*.rs");
+for $f (@files) {
+    next if $seen{$f}++;
+    @ARGV = $f;
+    # Wrap code with Markdown ``` code blocks
+    push @e, '```' . "rust\n";
+    my $in;
+    while (<>) {
+        # Extract code from fn main and outdent
+        $in = 1, next if /^fn main/;
+        $in = 0, next if /^}/;
+        s/^ {4}// if $in;
+        push @e, $_;
+    }
+    push @e, '```' . "\n\n";
+}
+my $examples = join('', @e);
+
+# Replace examples in the README
+$f = 'README.md';
+$body = slurp($f);
+$body =~ s{^(## Examples\n\n).+?^(\*)}{$1$examples$2}ms;
+save($f, $body);
+
+# Extract part of README we want to copy into source code documentation
+my $readme = slurp($f);
+$readme =~ s{.+?^(This crate .+?)\n^## Crates\.io.+}{$1}ms;
+$readme =~ s{^(?:\* )?}{//! }mg;
+$readme =~ s/ *$//msg;
+
+# Replace inner-line documentation with README extract
+$f = 'src/lib.rs';
+$body = slurp($f);
+$body =~ s{^//! This crate .+?\n(^[^/])}{$readme$1}ms;
+save($f, $body);
+
+
+sub slurp {
+    local @ARGV = $_[0];
+    local $/;
+    scalar <>
+}
+
+sub save {
+    open my $out, '>', $_[0] or die;
+    print $out $_[1];
+    close $out or die;
+}


### PR DESCRIPTION
Thanks for creating the `benchmarking` crate!

I'm new to Rust and followed your sample code `extern crate benchmarking` at first, but later noticed in [the docs](https://doc.rust-lang.org/reference/items/extern-crates.html):

> Beginning in the 2018 edition, use declarations can reference crates in the extern prelude, so it is considered unidiomatic to use extern crate.

So I went to update the `examples/*.rs` code for a pull request. Then I noticed the sample programs were out of sync between `examples/`, `README.md`, and the doc comments in `src/lib.rs`.

It was pretty quick to write a Perl program to synchronize them, so I did that and it's included here.

Maybe you already had a way of keeping them in sync, and if so no need for this, but it was quick to put together.